### PR TITLE
[DRIVE_MECHANICS] - Added zone for games that freeze

### DIFF
--- a/src/cmd.cpp
+++ b/src/cmd.cpp
@@ -279,6 +279,10 @@ void __time_critical_func(picostation::MechCommand::processLatchedCommand)()
 
 void __time_critical_func(picostation::MechCommand::setCLVModeStopKickPattern) (uint8_t clv_mode)
 {
+	// DISABLED: THE PROBLEM I WAS HAVING WAS SOLVED BY USING THE NEW ZONE 333000 AND ADJUSTING THE 999999
+	if (1 == 1)
+		return;
+		
 	switch (clv_mode)
 	{
 	case CLV_MODE_STOP:

--- a/src/drive_mechanics.cpp
+++ b/src/drive_mechanics.cpp
@@ -14,12 +14,12 @@
 #define DEBUG_PRINT(...) while (0)
 #endif
 
-#define ZONE_CNT 	16
+#define ZONE_CNT 	17
 #define ZONE_MAX 	ZONE_CNT-1
 
 extern picostation::I2S m_i2s;
-uint32_t zone[ZONE_CNT] = 			{4500, 7750, 13500, 27000, 45000, 63000, 85500, 103500, 130500, 153000, 175500, 207000, 234000, 265500, 297000, 999999};
-uint32_t sect_per_track[ZONE_CNT] = {	8,    9,    10,    11,    12,    13,    14,     15,     16,     17,     18,     19,     20,     21,     22,     23};
+uint32_t zone[ZONE_CNT] = 			{4500, 7750, 13500, 27000, 45000, 63000, 85500, 103500, 130500, 153000, 175500, 207000, 234000, 265500, 297000, 333000, 999999};
+uint32_t sect_per_track[ZONE_CNT] = {	8,    9,    10,    11,    12,    13,    14,     15,     16,     17,     18,     19,     20,     21,     22,     23,    8};
 
 picostation::DriveMechanics picostation::g_driveMechanics;
 


### PR DESCRIPTION
Added zone for games that freeze
KickPatter disabled, no longer needed. (It was left in case it is used; if not, remove it.)

Games with this error:
Winning Eleven 2002 in English on the START screen
Tactics Ogre on restart